### PR TITLE
Standardize Note references in UserGuide.

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -157,6 +157,8 @@ For example,
 
 will list all items that match at least one of the specified tags.
 
+NOTE: 'Note Fragments' are described further in the Notes section (see Section 6.1).
+
 === Exiting the application: `exit`
 
 Checks if there are any remaining flashcards to revise for the day
@@ -372,9 +374,11 @@ NOTE: The format for Note fragment content is 'C/', not 'c/', and the format for
         Content: Notes can be /* C/highlighted TAG/cs2100 TAG/important */ if needed
         Tags: [about]
 
-* Multiple intra-note tags are allowed. These do not interfere with the other tags of the Note.
+* Multiple note fragment tags are allowed. These do not interfere with the other tags of the Note.
 
-NOTE: Intra-note tags can be used for filtering notes (see Section 6.6), or filtering globally (see Section 4.3)
+NOTE: Note fragment tags can be used for filtering notes (see Section 6.6), or filtering globally (see Section 4.3).
+For a clearer visualization of note fragments, compare the `view` (see Section 6.3) and `viewraw` (see Section 6.4)
+commands.
 
 === Deleting a note: `delete`
 
@@ -392,9 +396,9 @@ Deletes the note of index `NOTE_INDEX`.
 
 === Viewing a note: `view`
 
-Views the note of index `NOTE_INDEX`. If the note contains any intra-note tags, those tags will be hidden.
+Views the note of index `NOTE_INDEX`. If the note contains any note fragment tags, those tags will be hidden.
 
-NOTE: To view the note with its intra-note tags, use the `viewraw` command instead (see Section 6.4).
+NOTE: To view the note with its note fragment tags, use the `viewraw` command instead (see Section 6.4).
 
     Format: view (index)
 
@@ -408,7 +412,7 @@ NOTE: To view the note with its intra-note tags, use the `viewraw` command inste
 
 === Viewing a raw note: `viewraw`
 
-Views the note of index `NOTE_INDEX`. The note is shown exactly as written, including all intra-note tags.
+Views the note of index `NOTE_INDEX`. The note is shown exactly as written, including all note fragment tags.
 
     Format: viewraw (index)
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -462,13 +462,36 @@ not tagged.
         4. Title: MA1521 Chapter 5
             Content: dy/dx = 0 is turning point of bellcurve.
             Tags: [difficult][MA1521]
+        5-1. Title: CS2103T
+              Content: sequence diagram
+              Tags: [difficult][diagram]
+
+NOTE: Notes will be labeled with indices '1', '2' etc. Note fragment tags will be labeled with '1-1', '1-2', '2-1' etc.
+'5-1' means 'the first note fragment tag in the fifth note'.
+
+=== Editing a note: `edit` (Coming in v2.0)
+
+Edits a note's title, content, or tags. The note will be referred to by their original title `ORIGINAL_TITLE`.
+
+* The user can specify one of the optional fields to edit.
+
+    Format: edit ORIGINAL_TITLE [t/TITLE] [c/CONTENT] [tag/TAG]...
+
+    Example usage: edit Pipelining Definition t/Pipelined Definition tag/cs2100finals
+
+    Expected output:
+    Edited Note:
+        Title: Pipelined Definition
+        Content: Pipelining is a process where a processor executes multiple processes simultaneously.
+        Tags: [cs2100finals]
 
 == CheatSheet Feature:
 
 === Creating a cheatSheet: `add`
 
 * Adds a cheatSheet from user input title <TITLE> and content <CONTENT>.
-* Flashcards and notes in StudyBuddyPro that have the specified tag will be pulled over to be used as content in the cheatsheet.
+* Flashcards and notes in StudyBuddyPro that have the specified tag will be pulled over to be used as content in the
+cheatsheet.
 
     Format: add t/TITLE [tag/TAG]...
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -96,19 +96,19 @@ Upon startup, you will be prompted to enter one of the modes before you can proc
 
 ==== Getting into Flashcard mode: `switch fc`
 
-Brings the user to the Flashcard section, regardless of where the user is.
+Brings the user to the Flashcard section (see Section 5), regardless of where the user is.
 
     Format: switch fc
 
 ==== Getting into Notes function: `switch notes`
 
-Brings the user to the Notes section, regardless of where the user is.
+Brings the user to the Notes section (see Section 6), regardless of where the user is.
 
     Format: switch notes
 
 ==== Getting into CheatSheet function: `switch cs`
 
-Brings the user to the CheatSheet section, regardless of where the user is.
+Brings the user to the CheatSheet section (see Section 7), regardless of where the user is.
 
     Format: switch cs
 
@@ -129,7 +129,7 @@ Lists all StudyBuddy items with matching tags in the application.
     Example usage: filterall tag/CS2100
 
     Expected output:
-        List the whole StudyBuddy by tag(s) :
+        Lists the whole StudyBuddy after filtering by tag(s) :
     CS2100
     Flashcard: 6.
         Question: What is 101 Binary in its Decimal form?

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -139,13 +139,13 @@ Lists all StudyBuddy items with matching tags in the application.
     CheatSheet: 7.
         Title: cs2100 stuff
         Tags: [cs2100]
-        Contents: [ 1. Pipelining is a process where.. ]
+        Contents: [ 1. Pipelining is a process where a processor executes multiple processes simultaneously.]
             [ 2. Question: What is 101 Binary in its Decimal form?; Answer: 5 ]
     Note: 5.
         Title: Pipelining Defition
-        Content: Pipelining is a process where..
+        Content: Pipelining is a process where a processor executes multiple processes simultaneously.
         Tags: [cs2100]
-    Note Fragment: 3.1.
+    Note Fragment: 6-2.
         Title: About
         Content: highlighted
         Tags: [cs2100]
@@ -338,27 +338,31 @@ If there are both flashcards due for revision today and overdue flashcards:
 
 === Creating a note: `add`
 
-* Adds a note from user input with title `TITLE` and content `CONTENT`.
+* Adds a note from user input with title `TITLE` and content `CONTENT`. The title of the note cannot be a duplicate
+of an existing note title.
 
     Format: add t/TITLE c/CONTENT [tag/TAG]...
 
-    Example usage: add t/Pipelining Definition c/Pipelining is a process where tag/CS2100
+    Example usage: add t/Pipelining Definition c/Pipelining is a process where a processor executes multiple processes
+    simultaneously. tag/CS2100
 
     Expected output:
     New note added:
         Title: Pipelining Definition
-        Content: Pipelining is a process where
+        Content: Pipelining is a process where a processor executes multiple processes simultaneously.
         Tags: [cs2100]
 
-* More advanced usage: Intra-Note tagging of note fragments is also supported. The intra-note tagging is added at the
-same time as the note is created. Intra-note tags are added with content `INTRA_CONTENT`, at least one tag
-`INTRA_TAG`, and any number of additional tags `ADDITIONAL_INTRA_TAG`:
+* More advanced usage: Tagging of note fragments is also supported. The note fragment tagging is added at the
+same time as the note is created.
 
-    Format (within CONTENT): /* C/INTRA_CONTENT TAG/INTRA_TAG [TAG/ADDITIONAL_INTRA_TAG]... */
+* Note fragment tags are added with content `FRAGMENT_CONTENT`, at least one tag
+`FRAGMENT_TAG`, and any number of additional tags `ADDITIONAL_FRAGMENT_TAG`:
 
-NOTE: The format for Intra-Note content is 'C/', not 'c/', and the format for Intra-Note tags is 'TAG/', not 'tag/'.
+    Format (within CONTENT): /* C/FRAGMENT_CONTENT TAG/FRAGMENT_TAG [TAG/ADDITIONAL_FRAGMENT_TAG]... */
 
-* In the following example, two intra-note tags are added:
+NOTE: The format for Note fragment content is 'C/', not 'c/', and the format for Note fragment tags is 'TAG/', not 'tag/'.
+
+* In the following example, two note fragment tags are added to the same note fragment:
 
     Example usage: add t/About c/Notes can be /* C/highlighted TAG/highlight TAG/important */ if needed. tag/about
 
@@ -424,13 +428,27 @@ Views the note of index `NOTE_INDEX`. The note is shown exactly as written, incl
 
    Expected output: a complete list of all notes currently in StudyBuddyPro
 
+    Example output:
+    Listing all notes:
+    1.
+        Title: Pipelining Definition
+        Content: Pipelining is a process where a /* C/processor TAG/mips */ executes multiple processes simultaneously.
+        Tags: [cs2100]
+    2.
+        Title: UML Diagrams
+        Content: UML Diagrams help with visualizing project structure.
+        Tags: [cs2103t]
+
+NOTE: Notes will be labeled with indices '1', '2' etc. Note fragment tags will not be listed along with the notes. To
+visualize specific note fragment tags, use the `filter` command (see Section 6.6).
+
 === Listing by tags: `filter`
 
 * Filters the note library by the user specified tag(s).
-* The user must specify at least one tag.
-* The user is able to specify multiple tags.
+* The user must specify at least one tag, and can specify multiple tags.
 * Notes that match at least one of the specified tags will be displayed.
-* Intra-Note tags containing at least one of the specified tags will also be displayed.
+* Note fragment tags containing at least one of the specified tags will also be displayed, even if their parent note is
+not tagged.
 
     Format: filter tag/TAG [tag/TAG]...
 

--- a/src/main/java/seedu/address/logic/commands/global/FilterAllByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/global/FilterAllByTagCommand.java
@@ -22,7 +22,7 @@ public class FilterAllByTagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters and displays every StudyBuddy item by tag(s)."
             + "\nExample usage : filterall tag/cs2100 tag/important";
 
-    public static final String FILTER_TAG_MESSAGE_SUCCESS = "List the whole StudyBuddy by tag(s): ";
+    public static final String FILTER_TAG_MESSAGE_SUCCESS = "Listing the whole StudyBuddy after filtering by tag(s): ";
 
     public static final String NO_ITEM_FOUND = "There is no such StudyBuddyItem with the specified "
             + "tag(s) in StudyBuddy!";
@@ -66,16 +66,16 @@ public class FilterAllByTagCommand extends Command {
         StringBuilder sb = new StringBuilder();
         for (String s : tagListResult) {
             sb.append(s);
-            sb.append("\n\n");
+            sb.append("\n");
         }
         StringBuilder resultToDisplay = new StringBuilder();
         if (tagListResult.size() == 0) {
             resultToDisplay.append(NO_ITEM_FOUND);
         } else {
             resultToDisplay.append(FILTER_TAG_MESSAGE_SUCCESS)
-                    .append("\n\n")
-                    .append(showTagQueries())
                     .append("\n")
+                    .append(showTagQueries())
+                    .append("\n\n")
                     .append(sb.toString());
         }
         return new GlobalCommandResult(resultToDisplay.toString());


### PR DESCRIPTION
Added:
- Edit Note feature as a v2.0 feature
Changed:
- 'Intra-Note tags' are now referred to as 'Note fragment tags'
- Examples used in Note commands are now similar