### PR TITLE
Items will only pass tag predicates if all matches

### DIFF
--- a/src/main/java/seedu/address/logic/commands/flashcard/FilterFlashcardByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/flashcard/FilterFlashcardByTagCommand.java
@@ -23,7 +23,7 @@ public class FilterFlashcardByTagCommand extends Command {
             + "related flashcards with the specified \n"
             + "tags. Example : filter tag/hard tag/cs2101";
 
-    public static final String FILTER_TAG_MESSAGE_SUCCESS = "Filter flashcards by tag(s) : ";
+    public static final String FILTER_TAG_MESSAGE_SUCCESS = "Filter flashcards by tag(s) :";
 
     public static final String NO_ITEM_FOUND = "There is no such FlashCard with the specified tag(s).";
 
@@ -76,6 +76,7 @@ public class FilterFlashcardByTagCommand extends Command {
             resultToDisplay.append(FILTER_TAG_MESSAGE_SUCCESS)
                     .append("\n")
                     .append(showTagQueries())
+                    .append("\n")
                     .append(sb.toString());
         }
         return new FlashcardCommandResult(resultToDisplay.toString());

--- a/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
@@ -18,8 +18,14 @@ public class StudyBuddyItemContainsTagPredicate implements Predicate<StudyBuddyI
     // test on the person to see if he has the tag
     @Override
     public boolean test(StudyBuddyItem studyBuddyItem) {
-        return tags.stream()
-                .allMatch(studyBuddyItem::containsTag);
+        boolean boo;
+        if (tags.isEmpty()) {
+            boo = false;
+        } else {
+            boo = tags.stream()
+                    .allMatch(studyBuddyItem::containsTag);
+        }
+        return boo;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
@@ -19,7 +19,7 @@ public class StudyBuddyItemContainsTagPredicate implements Predicate<StudyBuddyI
     @Override
     public boolean test(StudyBuddyItem studyBuddyItem) {
         return tags.stream()
-                .anyMatch(studyBuddyItem::containsTag);
+                .allMatch(studyBuddyItem::containsTag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/StudyBuddyItemContainsTagPredicate.java
@@ -18,14 +18,14 @@ public class StudyBuddyItemContainsTagPredicate implements Predicate<StudyBuddyI
     // test on the person to see if he has the tag
     @Override
     public boolean test(StudyBuddyItem studyBuddyItem) {
-        boolean boo;
+        boolean containsTag;
         if (tags.isEmpty()) {
-            boo = false;
+            containsTag = false;
         } else {
-            boo = tags.stream()
+            containsTag = tags.stream()
                     .allMatch(studyBuddyItem::containsTag);
         }
-        return boo;
+        return containsTag;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
@@ -18,14 +18,14 @@ public class CheatSheetContainsTagPredicate implements Predicate<CheatSheet> {
     // test on the flashcard to see if he has the tag
     @Override
     public boolean test(CheatSheet cheatSheet) {
-        boolean boo;
+        boolean containsTag;
         if (tags.isEmpty()) {
-            boo = false;
+            containsTag = false;
         } else {
-            boo = tags.stream()
+            containsTag = tags.stream()
                     .allMatch(cheatSheet::containsTag);
         }
-        return boo;
+        return containsTag;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
@@ -18,8 +18,14 @@ public class CheatSheetContainsTagPredicate implements Predicate<CheatSheet> {
     // test on the flashcard to see if he has the tag
     @Override
     public boolean test(CheatSheet cheatSheet) {
-        return tags.stream()
-                .allMatch(cheatSheet::containsTag);
+        boolean boo;
+        if (tags.isEmpty()) {
+            boo = false;
+        } else {
+            boo = tags.stream()
+                    .allMatch(cheatSheet::containsTag);
+        }
+        return boo;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicate.java
@@ -19,7 +19,7 @@ public class CheatSheetContainsTagPredicate implements Predicate<CheatSheet> {
     @Override
     public boolean test(CheatSheet cheatSheet) {
         return tags.stream()
-                .anyMatch(cheatSheet::containsTag);
+                .allMatch(cheatSheet::containsTag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
@@ -19,7 +19,7 @@ public class FlashcardContainsTagPredicate implements Predicate<Flashcard> {
     @Override
     public boolean test(Flashcard flashcard) {
         return tags.stream()
-                .anyMatch(flashcard::containsTag);
+                .allMatch(flashcard::containsTag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
@@ -18,14 +18,14 @@ public class FlashcardContainsTagPredicate implements Predicate<Flashcard> {
     // test on the flashcard to see if it has the tag
     @Override
     public boolean test(Flashcard flashcard) {
-        boolean boo;
+        boolean containsTag;
         if (tags.isEmpty()) {
-            boo = false;
+            containsTag = false;
         } else {
-            boo = tags.stream()
+            containsTag = tags.stream()
                     .allMatch(flashcard::containsTag);
         }
-        return boo;
+        return containsTag;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/flashcard/FlashcardContainsTagPredicate.java
@@ -18,8 +18,14 @@ public class FlashcardContainsTagPredicate implements Predicate<Flashcard> {
     // test on the flashcard to see if it has the tag
     @Override
     public boolean test(Flashcard flashcard) {
-        return tags.stream()
-                .allMatch(flashcard::containsTag);
+        boolean boo;
+        if (tags.isEmpty()) {
+            boo = false;
+        } else {
+            boo = tags.stream()
+                    .allMatch(flashcard::containsTag);
+        }
+        return boo;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
@@ -19,7 +19,7 @@ public class NoteContainsTagPredicate implements Predicate<Note> {
     @Override
     public boolean test(Note note) {
         return tags.stream()
-                .anyMatch(note::containsTag);
+                .allMatch(note::containsTag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
@@ -18,14 +18,14 @@ public class NoteContainsTagPredicate implements Predicate<Note> {
     // test on the note to see if he has the tag
     @Override
     public boolean test(Note note) {
-        boolean boo;
+        boolean containsTag;
         if (tags.isEmpty()) {
-            boo = false;
+            containsTag = false;
         } else {
-            boo = tags.stream()
+            containsTag = tags.stream()
                     .allMatch(note::containsTag);
         }
-        return boo;
+        return containsTag;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteContainsTagPredicate.java
@@ -18,8 +18,14 @@ public class NoteContainsTagPredicate implements Predicate<Note> {
     // test on the note to see if he has the tag
     @Override
     public boolean test(Note note) {
-        return tags.stream()
-                .allMatch(note::containsTag);
+        boolean boo;
+        if (tags.isEmpty()) {
+            boo = false;
+        } else {
+            boo = tags.stream()
+                    .allMatch(note::containsTag);
+        }
+        return boo;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
@@ -20,7 +20,7 @@ public class NoteFragmentContainsTagPredicate implements Predicate<NoteFragment>
     @Override
     public boolean test(NoteFragment noteFragment) {
         return tags.stream()
-                .anyMatch(noteFragment::containsTag);
+                .allMatch(noteFragment::containsTag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
@@ -19,8 +19,14 @@ public class NoteFragmentContainsTagPredicate implements Predicate<NoteFragment>
     // test on the note to see if he has the tag
     @Override
     public boolean test(NoteFragment noteFragment) {
-        return tags.stream()
-                .allMatch(noteFragment::containsTag);
+        boolean boo;
+        if (tags.isEmpty()) {
+            boo = false;
+        } else {
+            boo = tags.stream()
+                    .allMatch(noteFragment::containsTag);
+        }
+        return boo;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/note/NoteFragmentContainsTagPredicate.java
@@ -19,14 +19,14 @@ public class NoteFragmentContainsTagPredicate implements Predicate<NoteFragment>
     // test on the note to see if he has the tag
     @Override
     public boolean test(NoteFragment noteFragment) {
-        boolean boo;
+        boolean containsTag;
         if (tags.isEmpty()) {
-            boo = false;
+            containsTag = false;
         } else {
-            boo = tags.stream()
+            containsTag = tags.stream()
                     .allMatch(noteFragment::containsTag);
         }
-        return boo;
+        return containsTag;
     }
 
     @Override

--- a/src/test/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicateTest.java
+++ b/src/test/java/seedu/address/model/cheatsheet/CheatSheetContainsTagPredicateTest.java
@@ -62,18 +62,22 @@ public class CheatSheetContainsTagPredicateTest {
         assertTrue(predicate.test(new CheatSheetBuilder().withTags("first", "second").build()));
 
         // Only one matching keyword
-        predicate = new CheatSheetContainsTagPredicate(secondPredicateTagList);
-        assertTrue(predicate.test(new CheatSheetBuilder().withTags("first", "third").build()));
+        //predicate = new CheatSheetContainsTagPredicate(secondPredicateTagList);
+        //assertTrue(predicate.test(new CheatSheetBuilder().withTags("first", "third").build()));
 
         // Mixed-case keywords
-        predicate = new CheatSheetContainsTagPredicate(secondPredicateTagList);
-        assertTrue(predicate.test(new CheatSheetBuilder().withTags("first", "seCoUnD").build()));
+        //predicate = new CheatSheetContainsTagPredicate(secondPredicateTagList);
+        //assertTrue(predicate.test(new CheatSheetBuilder().withTags("first", "seCoUnD").build()));
     }
 
     @Test
     public void test_cheatSheetDoesNotContainTags_returnsFalse() {
         HashSet<Tag> firstPredicateTagList = new HashSet<>();
         firstPredicateTagList.add(new Tag("first"));
+
+        HashSet<Tag> secondPredicateTagList = new HashSet<>();
+        secondPredicateTagList.add(new Tag("first"));
+        secondPredicateTagList.add(new Tag("second"));
 
         // Zero keywords
         CheatSheetContainsTagPredicate predicate = new CheatSheetContainsTagPredicate(new HashSet<>());
@@ -86,5 +90,9 @@ public class CheatSheetContainsTagPredicateTest {
         // Matches title, but does not match tag
         predicate = new CheatSheetContainsTagPredicate(firstPredicateTagList);
         assertFalse(predicate.test(new CheatSheetBuilder().withTitle("first").withTags("third").build()));
+
+        // Only one matching keyword
+        predicate = new CheatSheetContainsTagPredicate(secondPredicateTagList);
+        assertFalse(predicate.test(new CheatSheetBuilder().withTags("first", "third").build()));
     }
 }


### PR DESCRIPTION
Previously
[cs2100] [difficult]
will take all items with individual tag cs2100 and difficult

now will only take items that have **both**
cs2100 and difficult